### PR TITLE
Escapes quotes in SQL input

### DIFF
--- a/db_writes.py
+++ b/db_writes.py
@@ -59,9 +59,10 @@ def get_posts(username):
         
 def get_item_data(itemdata):
     """get data on an item from the database"""
+    escaped_itemdata = itemdata.replace("'","''")
     with CON:
         cur = CON.cursor()
-        cur.execute(f"SELECT * FROM posts WHERE itemname = '{itemdata}'")
+        cur.execute(f"SELECT * FROM posts WHERE itemname = '{escaped_itemdata}'")
         rows = cur.fetchall()
         print(rows)
         item_data = {


### PR DESCRIPTION
Previously, if the title of an amazon item had an apostrophe like "Lay's Potato Chips", it would close the SQL query string and crash the app. 

This change automatically escapes all single quotes in the string with an additional single quote next to them.