### PR TITLE
Fixed CommentsSection using post author name/picture instead of user's name/picture

### DIFF
--- a/scripts/Content.jsx
+++ b/scripts/Content.jsx
@@ -181,6 +181,7 @@ export default function Content() {
               datapts={datapts}
               postOf={postOf}
               username={username}
+              profPic={profpic}
             />
           </Route>
         </Switch>

--- a/scripts/DetailedItem.jsx
+++ b/scripts/DetailedItem.jsx
@@ -49,7 +49,7 @@ export default function DetailedView(props) {
             </a>
           </div>
           <div className={"rightPage"}>
-            <h2>Visualization Graph</h2> <br />
+            <h2>Visualization Graph</h2><br/>
             <LineGraph
               className="graphcanvas"
               datapts={props.datapts}
@@ -58,8 +58,8 @@ export default function DetailedView(props) {
           </div>
         </div>
         <CommentsSection
-          username={props.user}
-          pfp={props.pfp}
+          username={props.username}
+          pfp={props.profPic}
           postID={props.postOf}
         />
       </div>


### PR DESCRIPTION
Changed some variables being sent to CommentsSection:
user->username 
pfp->profpic. 
CommentsSection will now use the local client's information to post comments. 