### PR TITLE
Fixed installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A browser-based price tracker application where users can type in about a produc
    to use [https://rapidapi.com/ajmorenodelarosa/api/amazon-price1/](https://rapidapi.com/ajmorenodelarosa/api/amazon-price1)
    and [https://rapidapi.com/Megatvini/api/amazon-price-history](https://rapidapi.com/Megatvini/api/amazon-price-history)
 7. After signing up for the API's create a `secret_tokens.env` file and add the following lines into the file:
-  ` RAPID_API_KEY=Your Key `
+  ` export RAPID_API_KEY=Your Key `
 8. To setup the google login button while starting up the application install this npm package by typing `npm install react-google-login`
    before starting up the application. Additional information about the npm package could be found at https://www.npmjs.com/package/react-google-login.
    After installing the npm package, follow the below steps to get the google login button setup:
@@ -54,7 +54,7 @@ A browser-based price tracker application where users can type in about a produc
     b) :warning: :warning: :warning: REPLACE THE [VALUES] IN THIS COMMAND! Type this with a new (short) unique password. I recommend 4-5 characters - it doesn't have to be very secure. Remember this password!   
         `create user [some_username_here] superuser password '[some_unique_new_password_here]';`    
     d) `\q` to quit out of sql    
-8. `cd` into `InstaPrice-Sprint2` and open `secret_tokens.env` and add `DATABASE_URL='postgresql://[your_unique_sql_username_here]:[your_unique_sql_password_here]@localhost/postgres'`
+8. `cd` into `InstaPrice-Sprint2` and open `secret_tokens.env` and add `export DATABASE_URL='postgresql://[your_unique_sql_username_here]:[your_unique_sql_password_here]@localhost/postgres'`
 9. Fill in SQL_USER and SQL_PASSWORD values with the values you put in 7. b)  
 10. Run `source secret_tokens.env`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A browser-based price tracker application where users can type in about a produc
 ## Heroku Link: [https://instaprice-490.herokuapp.com/](https://instaprice-490.herokuapp.com/)
 # Setting up
 1. To start using this project clone this repository by running `git clone https://github.com/pranavgajera/Instaprice-Sprint2` and then `cd Instaprice-Sprint2`
-2. Then install all the dependencies by running ` npm install && sudo pip3 install -r requirements.txt`
+2. Then install all the dependencies by running ` npm install && npm install --dev && sudo pip3 install -r requirements.txt`
 3.
 4. Update yum: `sudo yum update` and enter yes to all prompts.
 5. Upgrade pip: `sudo /usr/local/bin/pip install --upgrade pip`  

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ There's a special file that you need to enable your db admin password to work fo
 1. Open the file in vim: `sudo vim /var/lib/pgsql9/data/pg_hba.conf`
 If that doesn't work: `sudo vim $(psql -c "show hba_file;" | grep pg_hba.conf)`  
 2. Replace all values of `ident` with `md5` in Vim: `:%s/ident/md5/g`  
+3. Run `sudo service postgresql restart`
 
 # Running
 1. Run the application by running `npm run watch` on one terminal and `python app.py` in another terminal to start the application.


### PR DESCRIPTION
- Added `npm install --dev` to allow npm to automatically install all packages in DevDependencies in package.json.
- Added `export` to the environment variable declarations. Not adding export prevents python from accessing the variables.
- Added `sudo service postgresql restart` to instructions after changing configuration file. 
Note: If you want something installed via npm, we can simply add it to DevDependencies in package.json, and it should now automatically install. 